### PR TITLE
feat: offline downloads and dev build workflow

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -1,0 +1,21 @@
+name: Build Development APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter build apk --flavor development --target lib/main_development.dart
+      - uses: actions/upload-artifact@v4
+        with:
+          name: abs-wear-development-apk
+          path: build/app/outputs/flutter-apk/app-development.apk

--- a/lib/downloads/downloads.dart
+++ b/lib/downloads/downloads.dart
@@ -1,0 +1,1 @@
+export 'view/downloads_page.dart';

--- a/lib/downloads/view/downloads_page.dart
+++ b/lib/downloads/view/downloads_page.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:abs_wear/l10n/l10n.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:rotary_scrollbar/rotary_scrollbar.dart';
+
+import '../../player/view/player_page.dart';
+
+class DownloadsPage extends StatefulWidget {
+  const DownloadsPage({
+    required this.token,
+    required this.serverUrl,
+    super.key,
+  });
+
+  final String token;
+  final String serverUrl;
+
+  @override
+  State<DownloadsPage> createState() => _DownloadsPageState();
+}
+
+class _DownloadsPageState extends State<DownloadsPage> {
+  late Future<List<_DownloadItem>> _itemsFuture;
+  final PageController _pageController = PageController();
+
+  @override
+  void initState() {
+    super.initState();
+    _itemsFuture = _loadItems();
+  }
+
+  Future<List<_DownloadItem>> _loadItems() async {
+    final directory = await getApplicationDocumentsDirectory();
+    final items = <_DownloadItem>[];
+    await for (final entity in directory.list()) {
+      if (entity is Directory) {
+        final metaFile = File('${entity.path}/meta.json');
+        if (await metaFile.exists()) {
+          final json =
+              jsonDecode(await metaFile.readAsString()) as Map<String, dynamic>;
+          items.add(
+            _DownloadItem(
+              id: json['id'] as String,
+              title: (json['title'] as String?) ?? json['id'] as String,
+            ),
+          );
+        }
+      }
+    }
+    return items;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    return RotaryScrollWrapper(
+      rotaryScrollbar: RotaryScrollbar(
+        width: 2,
+        padding: 1,
+        hasHapticFeedback: false,
+        autoHide: false,
+        controller: _pageController,
+      ),
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(l10n.downloads),
+          automaticallyImplyLeading: false,
+        ),
+        body: FutureBuilder<List<_DownloadItem>>(
+          future: _itemsFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final data = snapshot.data ?? [];
+            if (data.isEmpty) {
+              return Center(child: Text(l10n.noDownloads));
+            }
+            return ListView.builder(
+              controller: _pageController,
+              itemCount: data.length,
+              itemBuilder: (context, index) {
+                final item = data[index];
+                return ListTile(
+                  title: Text(
+                    item.title,
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => PlayerPage(
+                          libraryItemId: item.id,
+                          serverUrl: widget.serverUrl,
+                          token: widget.token,
+                        ),
+                      ),
+                    );
+                  },
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _DownloadItem {
+  const _DownloadItem({required this.id, required this.title});
+  final String id;
+  final String title;
+}

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -53,5 +53,13 @@
     "localListening": "Local Listening",
     "@localListening": {
         "description": "Text for local listening"
+    },
+    "downloads": "Downloads",
+    "@downloads": {
+        "description": "Text for downloads page"
+    },
+    "noDownloads": "No downloads",
+    "@noDownloads": {
+        "description": "Text shown when no downloads are available"
     }
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -53,5 +53,13 @@
     "localListening": "Local Listening",
     "@localListening": {
         "description": "Text for local listening"
+    },
+    "downloads": "Downloads",
+    "@downloads": {
+        "description": "Text for downloads page"
+    },
+    "noDownloads": "No downloads",
+    "@noDownloads": {
+        "description": "Text shown when no downloads are available"
     }
 }

--- a/lib/login/view/login_page.dart
+++ b/lib/login/view/login_page.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'dart:ui' as ui;
 
 import 'package:abs_wear/l10n/l10n.dart';
+import 'package:abs_wear/downloads/downloads.dart';
 import 'package:abs_wear/library/view/library_page.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -277,6 +278,24 @@ class LoginPageState extends State<LoginPage> {
           },
           child: Text(
             l10n.library,
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+        const SizedBox(height: 8),
+        ElevatedButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => DownloadsPage(
+                  token: _token,
+                  serverUrl: serverUrlController.text,
+                ),
+              ),
+            );
+          },
+          child: Text(
+            l10n.downloads,
             style: theme.textTheme.bodyMedium,
           ),
         ),

--- a/lib/player/darts/audio_player.dart
+++ b/lib/player/darts/audio_player.dart
@@ -288,6 +288,15 @@ class AudioPlayerController extends ChangeNotifier {
         }
         // Delete the zip file
         zipFile.deleteSync();
+
+        // Save metadata for offline listing
+        final metaFile = File('$folderPath/meta.json');
+        await metaFile.writeAsString(
+          jsonEncode(<String, String>{
+            'id': libraryItemId,
+            'title': bookTitle,
+          }),
+        );
       }
       await Fluttertoast.showToast(
         msg: 'Audiobook downloaded!',


### PR DESCRIPTION
## Summary
- add downloads page to play cached audiobooks
- persist metadata when downloading
- add GitHub Actions workflow for dev APK

## Testing
- `flutter test --coverage --test-randomize-ordering-seed random` *(fails: Because abs_wear depends on flutter_localizations from sdk which depends on intl 0.19.0, intl 0.19.0 is required. So, because abs_wear depends on intl ^0.18.0, version solving failed.)*


------
https://chatgpt.com/codex/tasks/task_e_6897c5d4dd5c8320b46ac00d25bce95b